### PR TITLE
[ChannelPool] Implement connClosed callback

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -8,25 +8,44 @@ import (
 	"time"
 )
 
+// CloseConnReason describes why does the pool close a connection
+type CloseConnReason string
+
+const (
+	ConnUnusable CloseConnReason = "unusable"
+	ConnTimeout  CloseConnReason = "timeout"
+	PoolFull     CloseConnReason = "poolFull"
+	PoolClosed   CloseConnReason = "poolClosed"
+)
+
 // channelPool implements the Pool interface based on buffered channels.
 type channelPool struct {
 	// storage for our net.Conn connections
-	mu    	sync.RWMutex
-	conns 	chan *connInfo
+	mu    sync.RWMutex
+	conns chan *connInfo
 	// every connection's timeout
 	timeout time.Duration
 
-	// net.Conn generator
-	factory Factory
+	callbacks Callbacks
 }
 
 type connInfo struct {
-	conn 		net.Conn
-	createTime 	time.Time
+	conn       net.Conn
+	createTime time.Time
+}
+
+// Callbacks contains all callbacks to the channel pool user
+type Callbacks struct {
+	// net.Conn generator
+	Factory    Factory
+	ConnClosed ConnClosedCallback
 }
 
 // Factory is a function to create new connections.
 type Factory func() (net.Conn, error)
+
+// ConnClosedCallback is a function to notify there is a connection has been closed.
+type ConnClosedCallback func(reason CloseConnReason, err error)
 
 // NewChannelPool returns a new pool based on buffered channels with an initial
 // capacity and maximum capacity. Factory is used when initial capacity is
@@ -34,21 +53,21 @@ type Factory func() (net.Conn, error)
 // until a new Get() is called. During a Get(), If there is no new connection
 // available in the pool, a new connection will be created via the Factory()
 // method.
-func NewChannelPool(initialCap, maxCap int, factory Factory, timeout time.Duration) (Pool, error) {
+func NewChannelPool(initialCap, maxCap int, callbacks Callbacks, timeout time.Duration) (Pool, error) {
 	if initialCap < 0 || maxCap <= 0 || initialCap > maxCap {
 		return nil, errors.New("invalid capacity settings")
 	}
 
 	c := &channelPool{
-		conns:   make(chan *connInfo, maxCap),
-		factory: factory,
-		timeout: timeout,
+		conns:     make(chan *connInfo, maxCap),
+		callbacks: callbacks,
+		timeout:   timeout,
 	}
 
 	// create initial connections, if something goes wrong,
 	// just close the pool error out.
 	for i := 0; i < initialCap; i++ {
-		conn, err := factory()
+		conn, err := callbacks.Factory()
 		if err != nil {
 			c.Close()
 			return nil, fmt.Errorf("factory is not able to fill the pool: %s", err)
@@ -59,19 +78,19 @@ func NewChannelPool(initialCap, maxCap int, factory Factory, timeout time.Durati
 	return c, nil
 }
 
-func (c *channelPool) getConnsAndFactory() (chan *connInfo, Factory) {
+func (c *channelPool) getConnsAndCallbacks() (chan *connInfo, Callbacks) {
 	c.mu.RLock()
 	conns := c.conns
-	factory := c.factory
+	callbacks := c.callbacks
 	c.mu.RUnlock()
-	return conns, factory
+	return conns, callbacks
 }
 
 // Get implements the Pool interfaces Get() method. If there is no new
 // connection available in the pool, a new connection will be created via the
 // Factory() method.
 func (c *channelPool) Get() (net.Conn, error) {
-	conns, factory := c.getConnsAndFactory()
+	conns, callbacks := c.getConnsAndCallbacks()
 	if conns == nil {
 		return nil, ErrClosed
 	}
@@ -88,7 +107,8 @@ func (c *channelPool) Get() (net.Conn, error) {
 			if timeout := c.timeout; timeout > 0 {
 				if connInfo.createTime.Add(timeout).Before(time.Now()) {
 					if connInfo.conn != nil {
-						connInfo.conn.Close()
+						c.closeConn(connInfo.conn, ConnTimeout, callbacks.ConnClosed)
+
 					}
 					continue
 				}
@@ -96,7 +116,7 @@ func (c *channelPool) Get() (net.Conn, error) {
 
 			return c.wrapConn(connInfo.conn), nil
 		default:
-			conn, err := factory()
+			conn, err := callbacks.Factory()
 			if err != nil {
 				return nil, err
 			}
@@ -118,7 +138,7 @@ func (c *channelPool) put(conn net.Conn) error {
 
 	if c.conns == nil {
 		// pool is closed, close passed connection
-		return conn.Close()
+		return c.closeConn(conn, PoolClosed, c.callbacks.ConnClosed)
 	}
 
 	// put the resource back into the pool. If the pool is full, this will
@@ -128,7 +148,7 @@ func (c *channelPool) put(conn net.Conn) error {
 		return nil
 	default:
 		// pool is full, close passed connection
-		return conn.Close()
+		return c.closeConn(conn, PoolFull, c.callbacks.ConnClosed)
 	}
 }
 
@@ -136,7 +156,8 @@ func (c *channelPool) Close() {
 	c.mu.Lock()
 	conns := c.conns
 	c.conns = nil
-	c.factory = nil
+	connClosedCallback := c.callbacks.ConnClosed
+	c.callbacks = Callbacks{}
 	c.mu.Unlock()
 
 	if conns == nil {
@@ -145,11 +166,19 @@ func (c *channelPool) Close() {
 
 	close(conns)
 	for connInfo := range conns {
-		connInfo.conn.Close()
+		c.closeConn(connInfo.conn, PoolClosed, connClosedCallback)
 	}
 }
 
 func (c *channelPool) Len() int {
-	conns, _ := c.getConnsAndFactory()
+	conns, _ := c.getConnsAndCallbacks()
 	return len(conns)
+}
+
+func (c *channelPool) closeConn(conn net.Conn, reason CloseConnReason, cb ConnClosedCallback) error {
+	err := conn.Close()
+	if cb != nil {
+		cb(reason, err)
+	}
+	return err
 }

--- a/conn.go
+++ b/conn.go
@@ -21,7 +21,8 @@ func (p *PoolConn) Close() error {
 
 	if p.unusable {
 		if p.Conn != nil {
-			return p.Conn.Close()
+			_, callbacks := p.c.getConnsAndCallbacks()
+			return p.c.closeConn(p.Conn, ConnUnusable, callbacks.ConnClosed)
 		}
 		return nil
 	}


### PR DESCRIPTION
Summary:
To let ChannelPool user know that a connection has been closed.